### PR TITLE
Updated Sketch doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Sketch 3.2.1 or later on OSX Yosemite.
 
 ## More info
 
-If you are curious about scripting Sketch, here's a link to the official [Sketch Scripting API documentation](http://bohemiancoding.com/sketch/scripting/).
+If you are curious about scripting Sketch, here's a link to the official [Sketch Developer documentation](http://bohemiancoding.com/sketch/support/developer/).
 
 
 ## License


### PR DESCRIPTION
Seems the location for the official docs has chance since the README was originally created.
