### PR TITLE
Fixes for version 41 + respect Sketch artboard bg color option

### DIFF
--- a/Preview/Preview.sketchplugin
+++ b/Preview/Preview.sketchplugin
@@ -1,5 +1,5 @@
 // Preview design on browser (cmd shift .)
-
+var doc = context.document
 var artboard = [[doc currentPage] currentArtboard] || [doc currentPage];
 
 if ([artboard class] == "MSPage") {
@@ -9,7 +9,7 @@ if ([artboard class] == "MSPage") {
     var filename = NSTemporaryDirectory() + artboardname + ".png";
     [doc saveArtboardOrSlice:artboard toFile: filename];
 
-    var someContent = NSString.stringWithString_("<html><head><meta charset='UTF-8'></head><body style='text-align: center;    margin: 0; padding: 0; background: #" + [[artboard backgroundColor] hexValue] + ";'> <img src='./" + artboardname + ".png' center top no-repeat;'></body></html>");
+    var someContent = NSString.stringWithString_("<html><head><meta charset='UTF-8'></head><body style='text-align: center; margin: 0; padding: 0;'> <img src='./" + artboardname + ".png' center top no-repeat;'></body></html>");
     var filepath = NSTemporaryDirectory() + artboardname + ".html";
     someContent.dataUsingEncoding_(NSUTF8StringEncoding).writeToFile_atomically_(filepath, true);
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ Generates a preview of your current artboard and shows in your web browser.
 
 ##How to install it
 
-First of all you need to have [Sketch 3](http://bohemiancoding.com/sketch/) installed.
->Compatible with the current version 3.6 ( 26304 )
+First of all you need to have [Sketch](http://bohemiancoding.com/sketch/) installed.
+>Compatible with the current version 41 (35326)
+
 
 ###Use Sketch Toolbox (recommended)
 Use [Sketch Toolbox](http://sketchtoolbox.com/) to search for `Sketch Browser Preview` and click install.


### PR DESCRIPTION
This PR makes the plugin work with Sketch 41. Fixes an undefined variable and a change to how the background color is made available via the API. Now - as long as "Include in export" is checked on the artboard it will be exported as part of the image that is saved for preview (`artboard.backgroundColor().hexValue()` no longer seems to exist).