### PR TITLE
Fix "missing file" due to single quotes

### DIFF
--- a/BrowserPreview.sketchplugin/Contents/Sketch/preview.js
+++ b/BrowserPreview.sketchplugin/Contents/Sketch/preview.js
@@ -2,7 +2,7 @@
 
 var get_html = function(name, background) {
   return "<html><head><meta charset='UTF-8'></head>" +
-    "<body style='text-align: center;    margin: 0; padding: 0; background: " + background + ";'> <img src=\"./" + name + ".webp\" center top no-repeat;'></body></html>";
+    "<body style='text-align: center;    margin: 0; padding: 0; background: " + background + ";'> <img src=\"./" + encodeURIComponent(name) + ".webp\" center top no-repeat;'></body></html>";
 }
 
 var get_background = function(artboard) {

--- a/BrowserPreview.sketchplugin/Contents/Sketch/preview.js
+++ b/BrowserPreview.sketchplugin/Contents/Sketch/preview.js
@@ -2,7 +2,7 @@
 
 var get_html = function(name, background) {
   return "<html><head><meta charset='UTF-8'></head>" +
-    "<body style='text-align: center;    margin: 0; padding: 0; background: " + background + ";'> <img src='./" + name + ".webp' center top no-repeat;'></body></html>";
+    "<body style='text-align: center;    margin: 0; padding: 0; background: " + background + ";'> <img src=\"./" + name + ".webp\" center top no-repeat;'></body></html>";
 }
 
 var get_background = function(artboard) {


### PR DESCRIPTION
Because of the way the HTML string is constructed, having single quotes in the artboard name causes the webpage rendered after pressing Cmd+Shift+. to fail to display the image.

This fix uses double quotes for the `src` attribute value which allows the value to contain single quotes.